### PR TITLE
added: detect(inference only) face, crop face using YOLOv8

### DIFF
--- a/tools/crop_face.py
+++ b/tools/crop_face.py
@@ -3,7 +3,7 @@ import matplotlib.pyplot as plt
 from ultralytics.utils.plotting import save_one_box
 from PIL import Image
 
-def crop_face_yolo(target_size, bbox_xyxy, origin_array, padding_option:str="custom"):
+def crop_face_yolo(target_size, bbox_xyxy, origin_array, padding_option:str):
   """Crop face using bbox information
   Args:
     target_size  (int, int): (width, height) target size of cropped image,
@@ -12,7 +12,7 @@ def crop_face_yolo(target_size, bbox_xyxy, origin_array, padding_option:str="cus
     padding_option (str): 
       1) custom - PIL, add black pixels. 
       2) yolo - yolo padding - expand facial area
-      3) no_padding - only crop, no resizing (size will be different)
+      3) None - only crop, no resizing nor padding (size will be different)
   """
   if padding_option == "custom":  # custom padding with black pixels
     cropped_img_array = save_one_box(bbox_xyxy, origin_array, square=False, save=False)

--- a/tools/crop_face.py
+++ b/tools/crop_face.py
@@ -3,51 +3,49 @@ import matplotlib.pyplot as plt
 from ultralytics.utils.plotting import save_one_box
 from PIL import Image
 
-def crop_face_yolo(target_size, bbox_xyxy, origin_array, custom_padding:bool=True, yolo_padding:bool=False):
+def crop_face_yolo(target_size, bbox_xyxy, origin_array, padding_option:str="custom"):
   """Crop face using bbox information
   Args:
     target_size  (int, int): (width, height) target size of cropped image,
     bbox_results (dict): predicted bbox results for all directories
-    custom_padding (bool): if True: custom padding - PIL, add black pixels. if False: no padding, only crop (size will be different)
-    yolo_padding (bool, optional): yolo padding - expand facial area
+    origin_array (np.array): original image array
+    padding_option (str): 
+      1) custom - PIL, add black pixels. 
+      2) yolo - yolo padding - expand facial area
+      3) no_padding - only crop, no resizing (size will be different)
   """
-  if custom_padding == True: 
+  if padding_option == "custom":  # custom padding with black pixels
+    cropped_img_array = save_one_box(bbox_xyxy, origin_array, square=False, save=False)
+    face_pil = Image.fromarray(cropped_img_array)
+    original_size = face_pil.size
 
-    if yolo_padding == True:  # yolo padding - expand facial areas
-      cropped_img_array = save_one_box(bbox_xyxy, origin_array, square=True, save=False)
-      # resize 추가
-      img_pil = Image.fromarray(cropped_img_array)
-      resized_img_pil = img_pil.resize(target_size, Image.BICUBIC)
-      result_array = np.array(resized_img_pil)
-      print("yolo")
+    # Calculate the aspect ratio
+    aspect_ratio = original_size[0] / original_size[1]  # width / height
+    target_aspect_ratio = target_size[0] / target_size[1]  # width / height
 
-    else: # custom padding with black pixels
-      cropped_img_array = save_one_box(bbox_xyxy, origin_array, square=False, save=False)
-      face_pil = Image.fromarray(cropped_img_array)
-      original_size = face_pil.size
+    # Calculate the new size with padding
+    if aspect_ratio > target_aspect_ratio:
+      new_width = int(target_size[0])
+      new_height = int(target_size[0] / aspect_ratio)
+    else:
+      new_width = int(target_size[1] * aspect_ratio)
+      new_height = int(target_size[1])
 
-      # Calculate the aspect ratio
-      aspect_ratio = original_size[0] / original_size[1]  # width / height
-      target_aspect_ratio = target_size[0] / target_size[1]  # width / height
+    resized_image = face_pil.resize((new_width, new_height), Image.BICUBIC) # 1) resize
+    padded_image = Image.new("RGB", target_size, (0, 0, 0)) # 2) create an empty black canvas with target size
+    paste_position = ((target_size[0] - new_width) // 2, (target_size[1] - new_height) // 2) # 3) get a position to paste the resized image
+    padded_image.paste(resized_image, paste_position) # 4) paste image to black canvas
+    result_array = np.array(padded_image) # 5) convert to numpy array
 
-      # Calculate the new size with padding
-      if aspect_ratio > target_aspect_ratio:
-        new_width = int(target_size[0])
-        new_height = int(target_size[0] / aspect_ratio)
-      else:
-        new_width = int(target_size[1] * aspect_ratio)
-        new_height = int(target_size[1])
-
-      resized_image = face_pil.resize((new_width, new_height), Image.BICUBIC) # 1) resize
-      padded_image = Image.new("RGB", target_size, (0, 0, 0)) # 2) create an empty black canvas with target size
-      paste_position = ((target_size[0] - new_width) // 2, (target_size[1] - new_height) // 2) # 3) get a position to paste the resized image
-      padded_image.paste(resized_image, paste_position) # 4) paste image to black canvas
-      result_array = np.array(padded_image) # 5) convert to numpy array
-      print("custom")
-
+  elif padding_option == "yolo":  # yolo padding - expand facial areas
+    cropped_img_array = save_one_box(bbox_xyxy, origin_array, square=True, save=False)
+    # resize 추가
+    img_pil = Image.fromarray(cropped_img_array)
+    resized_img_pil = img_pil.resize(target_size, Image.BICUBIC)
+    result_array = np.array(resized_img_pil)
+      
   else: # no resizing, only crop
     result_array = save_one_box(bbox_xyxy, origin_array, square=False, save=False)
-    print("no resize")
     
   return result_array
   

--- a/tools/crop_face.py
+++ b/tools/crop_face.py
@@ -1,0 +1,53 @@
+import numpy as np
+import matplotlib.pyplot as plt
+from ultralytics.utils.plotting import save_one_box
+from PIL import Image
+
+def crop_face_yolo(target_size, bbox_xyxy, origin_array, custom_padding:bool=True, yolo_padding:bool=False):
+  """Crop face using bbox information
+  Args:
+    target_size  (int, int): (width, height) target size of cropped image,
+    bbox_results (dict): predicted bbox results for all directories
+    custom_padding (bool): if True: custom padding - PIL, add black pixels. if False: no padding, only crop (size will be different)
+    yolo_padding (bool, optional): yolo padding - expand facial area
+  """
+  if custom_padding == True: 
+
+    if yolo_padding == True:  # yolo padding - expand facial areas
+      cropped_img_array = save_one_box(bbox_xyxy, origin_array, square=True, save=False)
+      # resize 추가
+      img_pil = Image.fromarray(cropped_img_array)
+      resized_img_pil = img_pil.resize(target_size, Image.BICUBIC)
+      result_array = np.array(resized_img_pil)
+      print("yolo")
+
+    else: # custom padding with black pixels
+      cropped_img_array = save_one_box(bbox_xyxy, origin_array, square=False, save=False)
+      face_pil = Image.fromarray(cropped_img_array)
+      original_size = face_pil.size
+
+      # Calculate the aspect ratio
+      aspect_ratio = original_size[0] / original_size[1]  # width / height
+      target_aspect_ratio = target_size[0] / target_size[1]  # width / height
+
+      # Calculate the new size with padding
+      if aspect_ratio > target_aspect_ratio:
+        new_width = int(target_size[0])
+        new_height = int(target_size[0] / aspect_ratio)
+      else:
+        new_width = int(target_size[1] * aspect_ratio)
+        new_height = int(target_size[1])
+
+      resized_image = face_pil.resize((new_width, new_height), Image.BICUBIC) # 1) resize
+      padded_image = Image.new("RGB", target_size, (0, 0, 0)) # 2) create an empty black canvas with target size
+      paste_position = ((target_size[0] - new_width) // 2, (target_size[1] - new_height) // 2) # 3) get a position to paste the resized image
+      padded_image.paste(resized_image, paste_position) # 4) paste image to black canvas
+      result_array = np.array(padded_image) # 5) convert to numpy array
+      print("custom")
+
+  else: # no resizing, only crop
+    result_array = save_one_box(bbox_xyxy, origin_array, square=False, save=False)
+    print("no resize")
+    
+  return result_array
+  

--- a/tools/detect_face.py
+++ b/tools/detect_face.py
@@ -15,19 +15,20 @@ def detect_bbox_yolo(dir_option:tuple, source_root:str, save_cropped_dir:str=Non
         save_cropped_dir (str, optional): save cropped image directory. Defaults to None.
         weights_path (str): a path of pretrained weights to load 
         target_size (tuple, optional): (width, height) target size of cropped image. Defaults to (224,224).
-        custom_padding (bool, optional): if True: custom padding - PIL, add black pixels. if False: no padding, only crop (size will be different). Defaults to True.
-        yolo_padding (bool, optional): yolo padding - expand facial area. Defaults to False.
+        padding_option (str): 
+            1) custom - PIL, add black pixels. 
+            2) yolo - yolo padding - expand facial area
+            3) no_padding - only crop, no resizing (size will be different)
     Returns: 
         all_pred_bbox_results (dict): predicted bbox results for all directories
     """
-    
     # dirs = ["train", "val", "test"]
     dirs = dir_option
     model = YOLO(weights_path)
 
-    all_pred_bbox_results = {}
+    # all_pred_bbox_results = {}
     for dir in dirs:
-        pred_bbox_results = {}
+        # pred_bbox_results = {}
         emotions = os.listdir(os.path.join(source_root, dir))
         for emotion in emotions:
             sources = os.path.join(source_root, dir, emotion) + "/*.jpg"
@@ -76,15 +77,13 @@ def main(cfg):
     weights_path = cfg.weights_path
     target_size = tuple(cfg.target_size)
     padding_option = cfg.padding_option
-    detect_results = detect_bbox_yolo(dir_option, src_data_path, dst_data_path, bbox_data_path, weights_path, target_size, padding_option)
+    detect_bbox_yolo(dir_option, src_data_path, dst_data_path, bbox_data_path, weights_path, target_size, padding_option)
     
     # bbox 정보 저장하는 부분 주석 처리함.
     # detect_results = detect_bbox_yolo(dir_option, src_data_path, dst_data_path, bbox_data_path, weights_path, target_size, padding_option)
     # with open(os.path.join(dst_data_path, "detect_info.json"), "w") as json_file:
     #     json.dumps(detect_results, indent=4, default=convert_to_json_serializable)
     # print(dir, ": finished!")
-
-    
 
 if __name__ == "__main__":
   parser = argparse.ArgumentParser()

--- a/tools/detect_face.py
+++ b/tools/detect_face.py
@@ -70,7 +70,6 @@ def detect_bbox_yolo(dir_option:tuple, source_root:str, save_cropped_dir:str=Non
 
 def main(cfg):
     dir_option = tuple(cfg.dir_option)
-    print(dir_option)
     src_data_path = cfg.src_data_path
     dst_data_path = cfg.dst_data_path
     bbox_data_path = cfg.bbox_data_path
@@ -88,13 +87,13 @@ def main(cfg):
 if __name__ == "__main__":
   parser = argparse.ArgumentParser()
   
-  parser.add_argument("--dir-option", nargs="+", type=str, default=("train", "val", "test"), help="choose specific folders to detect&crop")
+  parser.add_argument("--dir-option", nargs="+", type=str, default=("train", "val", "test"), choices=["train", "val", "test"], help="choose specific folders to detect&crop")
   parser.add_argument("--src-data-path", type=str, default="../data/images", help="path where contains source images") 
   parser.add_argument("--dst-data-path", type=str, default="../cropped_data", help="destination path for cropped image") 
   parser.add_argument("--bbox-data-path", type=str, default=None, help="save original image with bbox printed") 
   parser.add_argument("--weights-path", type=str, default="/home/KDT-admin/work/weights/yolov8n-face.pt", help="pretrained weights path to load") 
   parser.add_argument("--target-size", nargs=2, type=int, default=(224, 224), help="target cropping image size, separated by space, example: 224 224")  
-  parser.add_argument("--padding-option", type=str, default="custom", choices=["custom", "yolo", "no_padding"], help="custom: resizing and add black pixels, yolo: no black pad, expand facial area to resize, no_padding: only crop, no resizing")
+  parser.add_argument("--padding-option", type=str, default=None, choices=["custom", "yolo"], help="custom: resizing and add black pixels, yolo: no black pad, expand facial area to resize, no_padding: only crop, no resizing")
   config = parser.parse_args()
 
   main(config)

--- a/tools/detect_face.py
+++ b/tools/detect_face.py
@@ -1,0 +1,84 @@
+import argparse
+import os
+import numpy as np
+import matplotlib.pyplot as plt
+from crop_face import crop_face_yolo
+from ultralytics import YOLO
+
+def detect_bbox_yolo(source_root:str, save_cropped_dir:str=None, save_bbox_dir:str=None, weights_path:str=None, target_size:tuple=(224,224), custom_padding:bool=True, yolo_padding:bool=False):
+    """Detect face using yolov8 pretrained, save predicted bbox information
+    Args:
+        source_root (str): source directory
+        save_bbox_dir (str, optional): save bbox image directory. Defaults to None.
+        save_cropped_dir (str, optional): save cropped image directory. Defaults to None.
+        weights_path (str): a path of pretrained weights to load 
+        target_size (tuple, optional): (width, height) target size of cropped image. Defaults to (224,224).
+        custom_padding (bool, optional): if True: custom padding - PIL, add black pixels. if False: no padding, only crop (size will be different). Defaults to True.
+        yolo_padding (bool, optional): yolo padding - expand facial area. Defaults to False.
+    Returns: 
+        all_pred_bbox_results (dict): predicted bbox results for all directories
+    """
+    source_root = source_root + "/images"
+    dirs = os.listdir(source_root)
+    
+    model = YOLO(weights_path)
+
+    all_pred_bbox_results = {}
+    for dir in dirs:
+        pred_bbox_results = {}
+        emotions = os.listdir(os.path.join(source_root, dir))
+        for emotion in emotions:
+            sources = os.path.join(source_root, dir, emotion) + "/*.jpg"
+            results = model(sources, stream=True) # YOLOv8 detection, return: predicted bbox, cropped image array
+            for result in results:
+                head, tail = os.path.split(result.path)
+                pred_bbox_results[emotion] = {tail: { 
+                    "filename": os.path.join(head.split('/')[-1], tail), # head.split('/')[-2]: emotion, tail: filename,
+                    "bbox_xywh": result.boxes.xywh,  # Boxes object for bounding box outputs
+                    "bbox_xyxy": result.boxes.xyxy,  # Boxes object for cropping
+                    "orig_shape":  result.orig_shape, # original image shape
+                    "origin_array": result.orig_img, # original image array 
+                }}
+                
+                if save_bbox_dir is not None:
+                    # bbox 결과 이미지 저장
+                    save_path = os.path.join(save_bbox_dir, dir, emotion)
+                    os.makedirs(save_path, exist_ok=True)
+                    result.save(filename=os.path.join(save_path, tail))
+
+                if save_cropped_dir is not None:
+                    # padding처리한 cropped 이미지 저장
+                    cropped_img_array = crop_face_yolo(target_size, result.boxes.xyxy[0], result.orig_img, custom_padding, yolo_padding)
+                    save_path = os.path.join(save_cropped_dir, dir, emotion)
+                    os.makedirs(save_path, exist_ok=True)
+                    plt.imsave(os.path.join(save_path, tail), cropped_img_array)
+
+        all_pred_bbox_results[dir] = pred_bbox_results
+        print(dir, ": finished!")
+    return all_pred_bbox_results
+
+def main(cfg):
+    src_data_path = cfg.src_data_path
+    dst_data_path = cfg.dst_data_path
+    bbox_data_path = cfg.bbox_data_path
+    weights_path = cfg.bbox_weights_path
+    target_size = cfg.target_size
+    custom_padding = cfg.custom_padding
+    yolo_padding = cfg.yolo_padding
+    detect_bbox_yolo(src_data_path, dst_data_path, bbox_data_path, target_size, custom_padding, yolo_padding)
+
+    
+
+if __name__ == "__main__":
+  parser = argparse.ArgumentParser()
+  
+  parser.add_argument("--src-data-path", type=str, default="../data")
+  parser.add_argument("--dst-data-path", type=str, default="../cropped_data") # destination path for cropped image  
+  parser.add_argument("--bbox-data-path", type=str, default=None) # for checking bbox in orginal image
+  parser.add_argument("--weights-path", type=str, default="/home/KDT-admin/work/weights/yolov8n-face.pt") # put pretrained weights path to load
+  parser.add_argument("--target_size", type=tuple, default=(224,224)) # target cropping image size
+  parser.add_argument("--custom_padding", type=bool, default=True) # if True: custom padding - PIL, add black pixels. if False: no padding, only crop (size will be different)
+  parser.add_argument("--yolo_padding", type=bool, default=False) # expand facial area.
+  config = parser.parse_args()
+
+  main(config)

--- a/tools/detect_face.py
+++ b/tools/detect_face.py
@@ -1,11 +1,13 @@
 import argparse
 import os
+import json
+import torch
 import numpy as np
 import matplotlib.pyplot as plt
 from crop_face import crop_face_yolo
 from ultralytics import YOLO
 
-def detect_bbox_yolo(source_root:str, save_cropped_dir:str=None, save_bbox_dir:str=None, weights_path:str=None, target_size:tuple=(224,224), custom_padding:bool=True, yolo_padding:bool=False):
+def detect_bbox_yolo(dir_option:tuple, source_root:str, save_cropped_dir:str=None, save_bbox_dir:str=None, weights_path:str=None, target_size:tuple=(224,224), padding_option:str="custom"):
     """Detect face using yolov8 pretrained, save predicted bbox information
     Args:
         source_root (str): source directory
@@ -18,9 +20,9 @@ def detect_bbox_yolo(source_root:str, save_cropped_dir:str=None, save_bbox_dir:s
     Returns: 
         all_pred_bbox_results (dict): predicted bbox results for all directories
     """
-    source_root = source_root + "/images"
-    dirs = os.listdir(source_root)
     
+    # dirs = ["train", "val", "test"]
+    dirs = dir_option
     model = YOLO(weights_path)
 
     all_pred_bbox_results = {}
@@ -32,7 +34,7 @@ def detect_bbox_yolo(source_root:str, save_cropped_dir:str=None, save_bbox_dir:s
             results = model(sources, stream=True) # YOLOv8 detection, return: predicted bbox, cropped image array
             for result in results:
                 head, tail = os.path.split(result.path)
-                pred_bbox_results[emotion] = {tail: { 
+                pred_bbox_results[emotion]= {tail: { 
                     "filename": os.path.join(head.split('/')[-1], tail), # head.split('/')[-2]: emotion, tail: filename,
                     "bbox_xywh": result.boxes.xywh,  # Boxes object for bounding box outputs
                     "bbox_xyxy": result.boxes.xyxy,  # Boxes object for cropping
@@ -48,37 +50,51 @@ def detect_bbox_yolo(source_root:str, save_cropped_dir:str=None, save_bbox_dir:s
 
                 if save_cropped_dir is not None:
                     # padding처리한 cropped 이미지 저장
-                    cropped_img_array = crop_face_yolo(target_size, result.boxes.xyxy[0], result.orig_img, custom_padding, yolo_padding)
+                    cropped_img_array = crop_face_yolo(target_size, result.boxes.xyxy[0], result.orig_img, padding_option)
+                    pred_bbox_results[emotion][tail].update({"cropped_array": cropped_img_array.tolist()})
                     save_path = os.path.join(save_cropped_dir, dir, emotion)
                     os.makedirs(save_path, exist_ok=True)
                     plt.imsave(os.path.join(save_path, tail), cropped_img_array)
 
         all_pred_bbox_results[dir] = pred_bbox_results
-        print(dir, ": finished!")
+    
     return all_pred_bbox_results
 
+def convert_to_json_serializable(obj):
+    if isinstance(obj, np.ndarray):
+        return obj.tolist()
+    elif torch.is_tensor(obj):
+        return obj.cpu().numpy().tolist()
+    else:
+        raise TypeError(f"Object of type {type(obj)} is not JSON serializable")
+
 def main(cfg):
+    dir_option = tuple(cfg.dir_option)
+    print(dir_option)
     src_data_path = cfg.src_data_path
     dst_data_path = cfg.dst_data_path
     bbox_data_path = cfg.bbox_data_path
-    weights_path = cfg.bbox_weights_path
-    target_size = cfg.target_size
-    custom_padding = cfg.custom_padding
-    yolo_padding = cfg.yolo_padding
-    detect_bbox_yolo(src_data_path, dst_data_path, bbox_data_path, target_size, custom_padding, yolo_padding)
+    weights_path = cfg.weights_path
+    target_size = tuple(cfg.target_size)
+    padding_option = cfg.padding_option
+    detect_results = detect_bbox_yolo(dir_option, src_data_path, dst_data_path, bbox_data_path, weights_path, target_size, padding_option)
+    
+    # with open(os.path.join(dst_data_path, "detect_info.json"), "w") as json_file:
+    #     json.dumps(detect_results, indent=4, default=convert_to_json_serializable)
+    # print(dir, ": finished!")
 
     
 
 if __name__ == "__main__":
   parser = argparse.ArgumentParser()
   
-  parser.add_argument("--src-data-path", type=str, default="../data")
-  parser.add_argument("--dst-data-path", type=str, default="../cropped_data") # destination path for cropped image  
-  parser.add_argument("--bbox-data-path", type=str, default=None) # for checking bbox in orginal image
-  parser.add_argument("--weights-path", type=str, default="/home/KDT-admin/work/weights/yolov8n-face.pt") # put pretrained weights path to load
-  parser.add_argument("--target_size", type=tuple, default=(224,224)) # target cropping image size
-  parser.add_argument("--custom_padding", type=bool, default=True) # if True: custom padding - PIL, add black pixels. if False: no padding, only crop (size will be different)
-  parser.add_argument("--yolo_padding", type=bool, default=False) # expand facial area.
+  parser.add_argument("--dir-option", nargs="+", type=str, default=("train", "val", "test"), help="choose specific folders to detect&crop")
+  parser.add_argument("--src-data-path", type=str, default="../data/images", help="path where contains source images") 
+  parser.add_argument("--dst-data-path", type=str, default="../cropped_data", help="destination path for cropped image") 
+  parser.add_argument("--bbox-data-path", type=str, default=None, help="save original image with bbox printed") 
+  parser.add_argument("--weights-path", type=str, default="/home/KDT-admin/work/weights/yolov8n-face.pt", help="pretrained weights path to load") 
+  parser.add_argument("--target-size", nargs=2, type=int, default=(224, 224), help="target cropping image size, separated by space, example: 224 224")  
+  parser.add_argument("--padding-option", type=str, default="custom", choices=["custom", "yolo", "no_padding"], help="custom: resizing and add black pixels, yolo: no black pad, expand facial area to resize, no_padding: only crop, no resizing")
   config = parser.parse_args()
 
   main(config)


### PR DESCRIPTION
### 작업 내용
1. Detect with Yolov8 (inference only)
- 사전 학습된 weights를 가지고 face detection을 진행한다.
- 이때 얻은 bbox 정보(xywh, xyxy), 파일 명 (/emotion/filename.jpg 형식도 받아옴), original img array 는 따로 저장할 수 있음. 

2. Crop 옵션 ([colab](https://colab.research.google.com/drive/1OcoRqC1_boS62iNtJBbKCqnsZiog3asi#scrollTo=dirbfYG8zYW6) 참고)
(1) custom_padding: True (target size로 resizing)
    (i) yolo_padding = True: 얼굴 외의 영역을 가져와서 최대한 정사각형 shape을 만드는 crop
    (ii) yolo_padding = False: 얼굴 영역 만을 가져오고, 남는 여백은 black padding을 넣는 crop
(2) custom_padding = False: resize하지 않고 원본에서 얼굴 영역 그대로 crop (output 사이즈 다 제각기 다름)


*[Detect & Crop face를 하기 위한 데이터 사전 준비 과정]*
1. 원천 데이터에서 원하는 비율로 selected_images 를 복사해올 거면 sample_data_into_yolo_structure수행
4. create_feature_dataset을 이용해서 한글 파일 명 변경, coco json 생성 및, 원하는 est_wassup_03 폴더로 데이터 복사
5. (cropped 잘 되었는지 확인하는 단순 테스트용이라면) 그렇게 생성한 데이터셋 경로에서 detect_face.py 실행
6. (최종 cropped 셋을 원한다면) create_yolo_detection_dataset 먼저 실행 시키고, 거기서 나온 best weights를 /work/weights 폴더 안에 넣어둔다. 그 다음 3번 진행
-----------------------------------------------------------------------------
input dir 구조: yolo, output dir 구조: yolo
```
/data
  /test
      /anger
      /happy
  train
     /anger
     /happy
```
